### PR TITLE
Feature: Swagger Docs for Resource-Related Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ The base technologies are JavaScript, HTML and CSS. The frontend leverages [Reac
         "deductible_donation": true
     }
 
-| Method | Endpoint                  | Required Request Body                  | Returns                                    | User Auth |
-| ------ | ------------------------- | -------------------------------------- | ------------------------------------------ | --------- |
-| GET    | `/resources`              | -                                      | `get all resources`                        |           |
-| GET    | `/resources/:resource_id` | -                                      | `get a resource by resource_id`            |           |
-| POST   | `/resources`              | `resource_name`,`category`,`condition` | `add a new resource to the db`             | `Admin`   |
-| PUT    | `/resources/:resource_id` | `resource_name`,`category`,`condition` | `update a resource by resource_id,`        | `Admin`   |
-| DELETE | `/resources/:resource_id` | -                                      | `delete a resource by resource_id from db` | `Admin`   |
+| Method | Endpoint                  | Required Request Body                  | Returns                                    | User Auth                  |
+| ------ | ------------------------- | -------------------------------------- | ------------------------------------------ | -------------------------- |
+| GET    | `/resources`              | -                                      | `get all resources`                        | Any, but must be logged in |
+| GET    | `/resources/:resource_id` | -                                      | `get a resource by resource_id`            | Any, but must be logged in |
+| POST   | `/resources`              | `resource_name`,`category`,`condition` | `add a new resource to the db`             | `Admin`                    |
+| PUT    | `/resources/:resource_id` | `resource_name`,`category`,`condition` | `update a resource by resource_id,`        | `Admin`                    |
+| DELETE | `/resources/:resource_id` | -                                      | `delete a resource by resource_id from db` | `Admin`                    |
 
 ## Resource Tickets
 

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -76,6 +76,8 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *                $ref: '#/components/schemas/Resource'
  *              example:
  *                - resource_id: 54
+ *                  created_at: "2022-01-13T20:54:47.222Z"
+ *                  updated_at: "2022-01-13T20:54:47.222Z"
  *                  resource_name: 'Mead Composition Notebook'
  *                  category: 'Office Supplies'
  *                  condition: 'New'
@@ -85,6 +87,8 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *                  monetary_value: '$2'
  *                  deductible_donation: false
  *                - resource_id: 27
+ *                  created_at: "2022-01-13T20:54:47.222Z"
+ *                  updated_at: "2022-01-13T20:54:47.222Z"
  *                  resource_name: 'Lenovo Chromebook S330'
  *                  category: 'Computers'
  *                  condition: 'New'
@@ -94,6 +98,8 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *                  monetary_value: '$250'
  *                  deductible_donation: true
  *                - resource_id: 33
+ *                  created_at: "2022-01-13T20:54:47.222Z"
+ *                  updated_at: "2022-01-13T20:54:47.222Z"
  *                  resource_name: 'Sharpie Pens (Black), 12pcs'
  *                  category: 'Office Supplies'
  *                  condition: 'New'

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -230,8 +230,74 @@ router.post(
   }
 );
 
-//update a resource
-
+/**
+ * @swagger
+ * /resources/{resource_id}:
+ *  put:
+ *    summary: Updates resource details
+ *    description: Allows you to edit information about a resource. Requires resource_name, category, and condition fields. Only information included in the request body will be altered about the resource in question (i.e. empty fields will be ignored).
+ *    tags:
+ *      - resource
+ *    security:
+ *      - okta: []
+ *    parameters:
+ *      - in: path
+ *        name: resource_id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: Numeric ID of the resource to edit
+ *    requestBody:
+ *      description: Information to update about the desired resource
+ *      content:
+ *        application/json:
+ *          schema:
+ *            $ref: '#/components/schemas/Resource'
+ *      required: true
+ *    responses:
+ *      '200':
+ *        description: Response from a successful resource update
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  description: Success message, including the ID of the updated resource
+ *                success:
+ *                  type: object
+ *                  description: Object containing all information pertaining to the newly updated resource
+ *              example:
+ *                message: "Resource '108' updated"
+ *                success:
+ *                  resource_id: 108
+ *                  created_at: "2022-01-18T22:00:08.001Z"
+ *                  updated_at: "2022-02-18T22:00:09.001Z"
+ *                  resource_name: "Logitech HD Webcam C310"
+ *                  category: "Electronics"
+ *                  condition: "Acceptable"
+ *                  assigned: false
+ *                  current_assignee: null
+ *                  previous_assignee: '12'
+ *                  monetary_value: $35
+ *                  deductible_donation: true
+ *      '401':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      '403':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      '404':
+ *        description: Resource with the given ID could not be found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  description: Error message returned by the API
+ *                  example: 'Not Found'
+ */
 router.put(
   '/:resource_id',
   authRequired,

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -11,15 +11,19 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *    Resource:
  *      type: object
  *      required:
- *        - resource_id
  *        - resource_name
  *        - category
  *        - condition
- *        - assigned
  *      properties:
  *        resource_id:
  *          type: integer
- *          description: Primary key referencing a resource's auto-assigned ID
+ *          description: Unique primary key referencing a resource's auto-assigned ID
+ *        created_at:
+ *          type: timestamp
+ *          description: Automatic date-time string from a resource's creation in the database
+ *        updated_at:
+ *          type: timestamp
+ *          description: Automatic date-time string from a resource's last update in the database
  *        resource_name:
  *          type: string
  *          description: The name of a resource
@@ -31,13 +35,13 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *          description: An evaluation of the resource's current condition
  *        assigned:
  *          type: boolean
- *          description: State of whether or not a resource is assigned to someone already
+ *          description: State of whether or not a resource is assigned to someone already - defaults to false
  *        current_assignee:
  *          type: string
- *          description: Foreign key referencing the profile_id of the current assignee
+ *          description: Foreign key referencing the profile_id of the current assignee - defaults to null
  *        previous_assignee:
  *          type: string
- *          description: Foreign key referencing the profile_id of the previous assignee
+ *          description: Foreign key referencing the profile_id of the previous assignee - defaults to null
  *        monetary_value:
  *          type: string
  *          description: The approximate price/value of the resource
@@ -169,8 +173,48 @@ router.get('/:resource_id', authRequired, (req, res) => {
     });
 });
 
-// add a resource to the resources database
-
+/**
+ * @swagger
+ * /resources:
+ *  post:
+ *    summary: Adds a new resource to the database
+ *    description: Posts a new resource object to the resources table, if the resource is validly formatted. You only need to include resource_name, category, and condition in the request body, but other fields that adhere to the schema can be included if desired. Only data provided in the request body will be reflected in the response body.
+ *    tags:
+ *      - resource
+ *    security:
+ *      - okta: []
+ *    requestBody:
+ *      description: Information about the resource to be posted
+ *      content:
+ *        application/json:
+ *          schema:
+ *            $ref: '#/components/schemas/Resource'
+ *      required: true
+ *    responses:
+ *      '200':
+ *        description: Response from successful post
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  description: Status of the request as a message
+ *                  type: string
+ *                resource:
+ *                  description: Object mirroring the newly created resource -- will only display keys included in the request body upon posting, even if other keys are present/made in the database at creation
+ *                  type: object
+ *              example:
+ *                message: 'success'
+ *                resource:
+ *                  resource_name: 'Composition Notebook'
+ *                  category: 'Office Supplies'
+ *                  condition: 'New'
+ *      '401':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      '403':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ */
 router.post(
   '/',
   authRequired,

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -62,12 +62,15 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  * @swagger
  * /resources:
  *  get:
- *    summary: Returns a list of resources
+ *    summary: Get the list of all resources
+ *    description: Provides a JSON array of resources (as objects) currently available for/assigned to clients
  *    tags:
  *      - resource
+ *    security:
+ *      - okta: []
  *    responses:
  *      '200':
- *        description: A JSON array of resources (as objects) currently available for/assigned to clients
+ *        description: An array of resource objects
  *        content:
  *          application/json:
  *            schema:
@@ -93,8 +96,8 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *                  category: 'Computers'
  *                  condition: 'New'
  *                  assigned: true
- *                  current_assignee: Rueben Andrews
- *                  previous_assignee: Hunter Phillips
+ *                  current_assignee: '5'
+ *                  previous_assignee: '4'
  *                  monetary_value: '$250'
  *                  deductible_donation: true
  *                - resource_id: 33
@@ -123,8 +126,34 @@ router.get('/', authRequired, (req, res) => {
     });
 });
 
-// get a resource by its id
-
+/**
+ * @swagger
+ * /resources/{resource_id}:
+ *  get:
+ *    summary: Get details about a single resource
+ *    tags:
+ *      - resource
+ *    security:
+ *      - okta: []
+ *    parameters:
+ *      - in: path
+ *        name: resource_id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: Numeric ID of the resource to look for
+ *    responses:
+ *      '200':
+ *        description: Information about a specific resource
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/Resource'
+ *      '401':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      '403':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ */
 router.get('/:resource_id', authRequired, (req, res) => {
   const id = req.params.resource_id;
   Resources.findByResourceId(id)

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -58,7 +58,51 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *        deductible_donation: true
  */
 
-// get all resources
+/**
+ * @swagger
+ * /resources:
+ *  get:
+ *    summary: Returns a list of resources
+ *    tags:
+ *      - resource
+ *    responses:
+ *      '200':
+ *        description: A JSON array of resources (as objects) currently available for/assigned to clients
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: array
+ *              items:
+ *                $ref: '#/components/schemas/Resource'
+ *              example:
+ *                - resource_id: 54
+ *                  resource_name: 'Mead Composition Notebook'
+ *                  category: 'Office Supplies'
+ *                  condition: 'New'
+ *                  assigned: false
+ *                  current_assignee: null
+ *                  previous_assignee: null
+ *                  monetary_value: '$2'
+ *                  deductible_donation: false
+ *                - resource_id: 27
+ *                  resource_name: 'Lenovo Chromebook S330'
+ *                  category: 'Computers'
+ *                  condition: 'New'
+ *                  assigned: true
+ *                  current_assignee: Rueben Andrews
+ *                  previous_assignee: Hunter Phillips
+ *                  monetary_value: '$250'
+ *                  deductible_donation: true
+ *                - resource_id: 33
+ *                  resource_name: 'Sharpie Pens (Black), 12pcs'
+ *                  category: 'Office Supplies'
+ *                  condition: 'New'
+ *                  assigned: false
+ *                  current_assignee: null
+ *                  previous_assignee: null
+ *                  monetary_value: '$15'
+ *                  deductible_donation: true
+ */
 router.get('/', authRequired, (req, res) => {
   Resources.findAll()
     .then((resources) => {

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -4,8 +4,61 @@ const Resources = require('./resourcesModel');
 const authRequired = require('../middleware/authRequired');
 const { adminRequired } = require('../middleware/permissionsRequired');
 
-//get all resources
+/**
+ * @swagger
+ * components:
+ *  schemas:
+ *    Resource:
+ *      type: object
+ *      required:
+ *        - resource_id
+ *        - resource_name
+ *        - category
+ *        - condition
+ *        - assigned
+ *      properties:
+ *        resource_id:
+ *          type: integer
+ *          description: Primary key referencing a resource's auto-assigned ID
+ *        resource_name:
+ *          type: string
+ *          description: The name of a resource
+ *        category:
+ *          type: string
+ *          description: The name of the category the resource belongs to
+ *        condition:
+ *          type: string
+ *          description: An evaluation of the resource's current condition
+ *        assigned:
+ *          type: boolean
+ *          description: State of whether or not a resource is assigned to someone already
+ *        current_assignee:
+ *          type: string
+ *          description: Foreign key referencing the profile_id of the current assignee
+ *        previous_assignee:
+ *          type: string
+ *          description: Foreign key referencing the profile_id of the previous assignee
+ *        monetary_value:
+ *          type: string
+ *          description: The approximate price/value of the resource
+ *        deductible_donation:
+ *          type: boolean
+ *          description: State of whether or not a resource is a deductible donation
+ *      example:
+ *        resource_id: 1
+ *        created_at: "2021-11-12T19:50:44.914Z"
+ *        updated_at: "2021-11-12T19:50:44.914Z"
+ *        resource_name: "MacBook Pro 2020"
+ *        category: "Computers"
+ *        condition: "Excellent"
+ *        assigned: true
+ *        current_assignee: "9"
+ *        previous_assignee: "7"
+ *        monetary_value: "$1000"
+ *        deductible_donation: true
+ */
 
+// get all resources
 router.get('/', authRequired, (req, res) => {
   Resources.findAll()
     .then((resources) => {

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -102,6 +102,10 @@ const { adminRequired } = require('../middleware/permissionsRequired');
  *                  previous_assignee: null
  *                  monetary_value: '$15'
  *                  deductible_donation: true
+ *      '401':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      '403':
+ *        $ref: '#/components/responses/UnauthorizedError'
  */
 router.get('/', authRequired, (req, res) => {
   Resources.findAll()

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -157,6 +157,17 @@ router.get('/', authRequired, (req, res) => {
  *        $ref: '#/components/responses/UnauthorizedError'
  *      '403':
  *        $ref: '#/components/responses/UnauthorizedError'
+ *      '404':
+ *        description: Resource with the given ID could not be found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  description: Error message returned by the API
+ *                  example: 'Resource not found, check the ID'
  */
 router.get('/:resource_id', authRequired, (req, res) => {
   const id = req.params.resource_id;
@@ -235,7 +246,7 @@ router.post(
  * /resources/{resource_id}:
  *  put:
  *    summary: Updates resource details
- *    description: Allows you to edit information about a resource. Requires resource_name, category, and condition fields. Only information included in the request body will be altered about the resource in question (i.e. empty fields will be ignored).
+ *    description: Allows you to edit information about a resource. Requires resource_name, category, and condition fields. Only information included in the request body will be altered about the resource in question (i.e. empty fields will be ignored). If the ID provided by the resource_id URL parameter is invalid, the request will time out (this needs to be addressed in the future).
  *    tags:
  *      - resource
  *    security:
@@ -286,17 +297,6 @@ router.post(
  *        $ref: '#/components/responses/UnauthorizedError'
  *      '403':
  *        $ref: '#/components/responses/UnauthorizedError'
- *      '404':
- *        description: Resource with the given ID could not be found
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  description: Error message returned by the API
- *                  example: 'Not Found'
  */
 router.put(
   '/:resource_id',

--- a/api/resources/resourcesRouter.js
+++ b/api/resources/resourcesRouter.js
@@ -321,8 +321,41 @@ router.put(
   }
 );
 
-//delete a resource
-
+/**
+ * @swagger
+ * /resources/{resource_id}:
+ *  delete:
+ *    summary: Deletes a resource from the database
+ *    description: If a resource with the ID provided as a URL parameter for this request exists, it will be deleted from the database. If the ID is invalid, the request will time out (this needs to be addressed in the future).
+ *    tags:
+ *      - resource
+ *    security:
+ *      - okta: []
+ *    parameters:
+ *      - in: path
+ *        name: resource_id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: Numeric ID of the resource to delete
+ *    responses:
+ *      '200':
+ *        description: Successful deletion of a resource
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  description: Message relaying a resource's successful deletion
+ *              example:
+ *                message: 'Resource deleted'
+ *      '401':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      '403':
+ *        $ref: '#/components/responses/UnauthorizedError'
+ */
 router.delete(
   '/:resource_id',
   authRequired,


### PR DESCRIPTION
## Description

Video Overview: [https://www.youtube.com/watch?v=DraI-upvN2o](https://www.youtube.com/watch?v=DraI-upvN2o)

This branch adds Swagger documentation above all of the current endpoints inside of the `resourcesRouter.js` file, based on information provided in the `README.md` file, table specifications inside of our current migration files, and the results of manually testing each of these API endpoints in Postman.

To view this documentation, start the backend API via `npm start` and visit [http://localhost:8080/api-docs/](http://localhost:8080/api-docs/) in a web browser.

## Discoveries

When an invalid resource ID is provided as a URL parameter for `PUT /resources/:resource_id` or `DELETE /resources/:resource_id`, the API times out, instead of returning a 404 error, as `GET /resources/:resource_id` correctly does at the moment; this needs to be addressed in a future update!

Related Tickets: [#112](https://trello.com/c/MyWv5lMZ/112)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes