### PR TITLE
Feature: Route for Current User Profile

### DIFF
--- a/api/profile/profileModel.js
+++ b/api/profile/profileModel.js
@@ -51,6 +51,23 @@ const findOrCreateProfile = async (profileObj) => {
   }
 };
 
+async function mentorApplicationData(profile_id) {
+  const [person] = await db('mentor_intake as m').where(
+    'm.profile_id',
+    profile_id
+  );
+
+  return person;
+}
+
+async function menteeApplicationData(profile_id) {
+  const [person] = await db('mentee_intake as m').where(
+    'm.profile_id',
+    profile_id
+  );
+  return person;
+}
+
 module.exports = {
   findAll,
   findBy,
@@ -60,4 +77,6 @@ module.exports = {
   remove,
   findOrCreateProfile,
   updateIsActive,
+  mentorApplicationData,
+  menteeApplicationData,
 };

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -9,6 +9,16 @@ const {
 const { validateUser } = require('../middleware/generalMiddleware');
 validateUser;
 
+// this will be modified to get profiles from the mentee_intake table once the seed data is cleaned up a bit and the profile_ids in the mentee intake tabler are updated and usable.
+router.get('/current_user_profile/', authRequired, async (req, res, next) => {
+  try {
+    const resp = await Profiles.mentorApplicationData(req.profile.profile_id);
+    res.status(200).json(resp);
+  } catch (error) {
+    next(error);
+  }
+});
+
 /**
  * @swagger
  * components:


### PR DESCRIPTION
I added a route to our profile router to populate the frontend's profile component. This task was largely completed as a means to get experience with Okta and learn how to use the Okta middleware to get the logged in user's profile information.

Here is a YouTube video giving an overview of the changes I've made: https://youtu.be/coT26X4nhXg

This is a duplicate pull request. My previous PR was sullied by me pushing changes up on a different machine, so I copied the changes I made from that branch and put them here, with a clean commit history. I did address the comment on my previous PR to use next() for error handling instead of always passing down a 500 status.

Contributing members:

Shane Gray <shane.dalton.gray@gmail.com> @Shane-Gray394
Emmanuel Gatica <egatica51@gmail.com> @mannig1224
Vicki Lei <ylei1088@gmail.com> @ylei1088
Adam Beuchert <addybeuch@gmail.com> @addybeuch

Fixes: Connecting FE profile component to available information in the database

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
