### PR TITLE
Feature/admin meeting profile view

### DIFF
--- a/api/meetings/meetingsModel.js
+++ b/api/meetings/meetingsModel.js
@@ -1,7 +1,11 @@
 const db = require('../../data/db-config');
 
 const findAll = async () => {
-  return await db('meetings');
+  //returns names and profile info based on the host
+  const meetings = await db('meetings as m')
+    .join('profiles as p', 'm.host_id', 'p.profile_id')
+    .select('m.*', 'p.first_name', ' p.last_name', 'p.email');
+  return meetings;
 };
 
 const findByMeetingId = async (meeting_id) => {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,14 +12,15 @@ ___Paste your trello card link here, deleting this example___
 
 (Example below):
 
-<blockquote class="trello-card"><a href="https://trello.com/c/ID37TYFd/240-as-an-admin-i-want-to-be-able-to-view-all-scheduled-meetings">Feature: As an admin, I want to be able to view all scheduled meetings.</a></blockquote>
+<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;JfipwNkb&#x2F;265-fix-refactor-sidebar-to-have-icons-representing-each-element-in-the-sidebar">Fix: Refactor sidebar to have icons representing each element in the sidebar</a></blockquote>
 
 ## Type of change
 
 ___Please delete options that are not relevant.___
 
-- [X] New feature (non-breaking change which adds functionality)
-- [X] This change requires a documentation update
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] This change requires a documentation update
 
 ## Checklist:
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,15 +12,14 @@ ___Paste your trello card link here, deleting this example___
 
 (Example below):
 
-<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;JfipwNkb&#x2F;265-fix-refactor-sidebar-to-have-icons-representing-each-element-in-the-sidebar">Fix: Refactor sidebar to have icons representing each element in the sidebar</a></blockquote>
+<blockquote class="trello-card"><a href="https://trello.com/c/ID37TYFd/240-as-an-admin-i-want-to-be-able-to-view-all-scheduled-meetings">Feature: As an admin, I want to be able to view all scheduled meetings.</a></blockquote>
 
 ## Type of change
 
 ___Please delete options that are not relevant.___
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] This change requires a documentation update
+- [X] New feature (non-breaking change which adds functionality)
+- [X] This change requires a documentation update
 
 ## Checklist:
 


### PR DESCRIPTION
## Description
in this PR I'm attempting to give back more information for the meetings endpoint so that the front end can have access to the name of the people attending the meetings. As of now the tables are join based on the host_id let me know if you think i should do it in another way.

## Video Link
 [https://www.loom.com/share/57fb08ac319e44bcb7274377841ca275 ](https://www.loom.com/share/57fb08ac319e44bcb7274377841ca275 )

#### Trello Link

<blockquote class="trello-card"><a href="https://trello.com/c/ID37TYFd/240-as-an-admin-i-want-to-be-able-to-view-all-scheduled-meetings">Feature: As an admin, I want to be able to view all scheduled meetings.</a></blockquote>

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
