### PR TITLE
removing redundant lines in dsconfig.js

### DIFF
--- a/config/dsConfig.js
+++ b/config/dsConfig.js
@@ -1,6 +1,3 @@
-var dotenv = require('dotenv');
-dotenv.config({ path: '../.env' });
-
 module.exports = {
   baseURL: process.env.DS_API_URL,
   headers: {


### PR DESCRIPTION
## Description

Removing 2 redundant lines in dsconfig.js. We already call env at the beginning of the app and would only need to do so again if we were calling another, separate env.

#### Video Link

[[Loom Video](Add your loom video link here)](https://www.loom.com/share/53169936858b45c5b6d2ffa9d091d8f5)

#### Trello Link

___Paste your trello card link here, deleting this example___

<blockquote class="trello-card"><a href="[https://trello.com/c/odbJC27z/367-fix-double-calling-of-env-in-dsconfigjs](https://trello.com/c/odbJC27z/367-fix-double-calling-of-env-in-dsconfigjs)">Fix: Refactor the first lines in dsconfig.js in config to prevent double calling of env</a></blockquote>

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
