### PR TITLE
updated current_user_profile to call getById to get the current user'…

### DIFF
--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -17,9 +17,7 @@ validateUser;
 
 router.get('/current_user_profile/', authRequired, async (req, res, next) => {
   try {
-    req.profile.attendance_rate = await Profiles.checkAverageAttendance(
-      req.profile.profile_id
-    );
+    req.profile = await Profiles.findById(req.profile.profile_id);
     res.status(200).json(req.profile);
   } catch (err) {
     next({ status: 500, message: err.message });


### PR DESCRIPTION
…s profile

## Description

Rewrote API endpoint current_user_profile to call getById from the router. This route is called each time a page is rendered regardless of if there is a current user or not. 

#### Video Link


https://www.loom.com/share/bbfcd3b4d8c547ba83df3dd133e503e7)

#### Trello Link

https://trello.com/c/1DwBFR4J/388-bug-the-endpoint-profile-currentuserprofile-calls-checkaverageattendance-in-checking-for-a-current-users-profile-id

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have removed unnecessary comments/console logs from my code
- [ x] My changes generate no new warnings
- [x ] I have checked my code and corrected any misspellings
- [x ] No duplicate code left within changed files
- [ x] Size of pull request kept to a minimum
- [x ] Pull request description clearly describes changes made & motivations for said changes
