### PR TITLE
add comments table and seed , get /notes/id/commit

### DIFF
--- a/api/notes/noteModel.js
+++ b/api/notes/noteModel.js
@@ -27,7 +27,9 @@ const update = (id, note) => {
 const remove = (id) => {
   return db('notes').where({ note_id: id }).del();
 };
-
+const getNoteComments = () => {
+  return db('comments as c').join('notes as n', 'c.note_id', 'n.note_id');
+};
 module.exports = {
   findAll,
   filterBy,
@@ -36,4 +38,5 @@ module.exports = {
   create,
   update,
   remove,
+  getNoteComments,
 };

--- a/api/notes/noteModel.js
+++ b/api/notes/noteModel.js
@@ -27,9 +27,14 @@ const update = (id, note) => {
 const remove = (id) => {
   return db('notes').where({ note_id: id }).del();
 };
-const getNoteComments = () => {
-  return db('comments as c').join('notes as n', 'c.note_id', 'n.note_id');
+const getNoteComments = (id) => {
+  return db
+    .from('comments as c')
+    .innerJoin('notes as n', 'c.note_id', 'n.note_id')
+    .select('comment_text', 'n.note_id')
+    .where('n.note_id', id);
 };
+
 module.exports = {
   findAll,
   filterBy,

--- a/api/notes/noteRouter.js
+++ b/api/notes/noteRouter.js
@@ -131,4 +131,13 @@ router.delete(
   }
 );
 
+router.get('/:id/comments', authRequired, async (req, res, next) => {
+  try {
+    const comments = await Notes.getNoteComments();
+    res.status(200).json(comments);
+  } catch (error) {
+    next(error);
+  }
+});
+
 module.exports = router;

--- a/api/notes/noteRouter.js
+++ b/api/notes/noteRouter.js
@@ -133,7 +133,7 @@ router.delete(
 
 router.get('/:id/comments', authRequired, async (req, res, next) => {
   try {
-    const comments = await Notes.getNoteComments();
+    const comments = await Notes.getNoteComments(req.params.id);
     res.status(200).json(comments);
   } catch (error) {
     next(error);

--- a/data/migrations/20220510183010_comments.js
+++ b/data/migrations/20220510183010_comments.js
@@ -1,0 +1,21 @@
+exports.up = function (knex) {
+  return knex.schema
+    .raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    .createTable('comments', function (table) {
+      table.increments('comment_id').notNullable().unique().primary();
+      table.text('comment_text').notNullable();
+      table
+        .integer('note_id')
+        .unsigned()
+        .notNullable()
+        .references('note_id')
+        .inTable('notes')
+        .onDelete('CASCADE')
+        .onUpdate('CASCADE');
+      table.timestamps(true, true);
+    });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('comments');
+};

--- a/data/seeds/017-comments.js
+++ b/data/seeds/017-comments.js
@@ -18,7 +18,7 @@ exports.seed = function (knex) {
         {
           comment_id: 3,
           comment_text: 'some text 3',
-          note_id: 1,
+          note_id: 2,
         },
       ]);
     });

--- a/data/seeds/017-comments.js
+++ b/data/seeds/017-comments.js
@@ -1,0 +1,25 @@
+exports.seed = function (knex) {
+  // Deletes ALL existing entries
+  return knex('comments')
+    .del()
+    .then(function () {
+      // Inserts seed entries
+      return knex('comments').insert([
+        {
+          comment_id: 1,
+          comment_text: 'some text 1',
+          note_id: 1,
+        },
+        {
+          comment_id: 2,
+          comment_text: 'some text 2',
+          note_id: 1,
+        },
+        {
+          comment_id: 3,
+          comment_text: 'some text 3',
+          note_id: 1,
+        },
+      ]);
+    });
+};


### PR DESCRIPTION
## Description

In this update, First, I create the comments table, then I create a seed, then I write the getNoteComments function in nodeModel.js, and write .router.get( /:id/comment) in noteRouter.js

I modified : 
api/notes/noteModel.js
api/notes/noteRouter.js
data/migrations/20220510183010_comments.js
data/seeds/017-comments.js

#### Video Link

https://loom.com/share/22534cffdf4448db9a859c959d71b9ce

#### Trello Link

https://trello.com/c/eOPWgjvA/323-as-a-user-i-would-like-to-be-able-to-add-a-reply-functionality-in-the-memo-in-order-for-the-user-to-respond-or-add-any-additiona

(Example below):

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;JfipwNkb&#x2F;265-fix-refactor-sidebar-to-have-icons-representing-each-element-in-the-sidebar">Fix: Refactor sidebar to have icons representing each element in the sidebar</a></blockquote>

## Type of change

___Please delete options that are not relevant.___

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
